### PR TITLE
fix the release of conda-forge after migrating to pytest

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,10 +18,11 @@ build:
 
 requirements:
   host:
-    - pip
     - python
+    - pip
     - setuptools
     - setuptools_scm
+    - pytest
   run:
     - python
 
@@ -31,9 +32,8 @@ test:
   requires:
     - pytest
   commands:
-    - echo 'TEST: Starting {{ name }} version {{ version }}'
-    - pytest --verbose petl
-    - echo 'TEST: Finished {{ name }} version {{ version }}'
+    - pytest --verbose
+#    - pytest --verbose petl
 
 about:
   home: http://github.com/petl-developers/petl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,13 +27,12 @@ requirements:
     - python
 
 test:
-  imports:
-    - petl
+#  imports:
+#    - petl
   requires:
     - pytest
   commands:
-    - pytest --verbose
-#    - pytest --verbose petl
+    - pytest --verbose petl
 
 about:
   home: http://github.com/petl-developers/petl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ test:
   imports:
     - petl
   commands:
-    - pytest -v petl
+    - pytest --verbose petl
 
 about:
   home: http://github.com/petl-developers/petl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,12 +26,14 @@ requirements:
     - python
 
 test:
-  requires:
-    - pytest
   imports:
     - petl
+  requires:
+    - pytest
   commands:
+    - echo 'TEST: Starting {{ name }} version {{ version }}'
     - pytest --verbose petl
+    - echo 'TEST: Finished {{ name }} version {{ version }}'
 
 about:
   home: http://github.com/petl-developers/petl


### PR DESCRIPTION
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

Fixing petl-developers/petl#583
