### PR TITLE
conda-forge build is working after pytest migration

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,22 +20,24 @@ build:
 
 requirements:
   host:
-    - python
+    - python >=3.6
     - pip
     - setuptools
     - setuptools_scm
-    - pytest
+    - pytest <7.0.0
   run:
-    - python
-    - pytest
+    - python >=3.6
+    - pytest <7.0.0
 
 test:
   imports:
     - petl
   requires:
-    - pytest
+    - pytest <7.0.0
   commands:
     - pytest --verbose petl
+  source_files:
+    - petl/
 
 about:
   home: http://github.com/petl-developers/petl


### PR DESCRIPTION
- After struggling for some time, now it worked in build_locally.sh!
- These should fix the release after migrating from nose to pytest

Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

