### PR TITLE
remove runtime dependency on pytest

### DIFF
--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -33,9 +33,9 @@ CONDARC
 
 
 mamba install --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-About petl
-==========
+About petl-feedstock
+====================
+
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/petl-feedstock/blob/main/LICENSE.txt)
 
 Home: http://github.com/petl-developers/petl
 
 Package license: MIT
-
-Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/petl-feedstock/blob/main/LICENSE.txt)
 
 Summary: A Python package for extracting, transforming and loading tables of data.
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,6 @@ requirements:
     - pytest <7.0.0
   run:
     - python >=3.6
-    - pytest <7.0.0
 
 test:
   imports:
@@ -35,6 +34,7 @@ test:
   requires:
     - pytest <7.0.0
   commands:
+    - pip check
     - pytest --verbose petl
   source_files:
     - petl/


### PR DESCRIPTION
## Checklist

* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

## Changes

- Fix #35 
