### PR TITLE
remove runtime dependency on pytest

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,6 @@ requirements:
     - pytest <7.0.0
   run:
     - python >=3.6
-    - pytest <7.0.0
 
 test:
   imports:
@@ -35,6 +34,7 @@ test:
   requires:
     - pytest <7.0.0
   commands:
+    - pip check
     - pytest --verbose petl
   source_files:
     - petl/


### PR DESCRIPTION
## Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

## Changes

- Fixes #35 

