### PR TITLE
Fix conda build missing pip

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ test:
   requires:
     - pytest <7.0.0
   commands:
-    - pip check
+    - which pip3 && pip3 check || echo Missing pip3 in the environment
     - pytest --verbose petl
   source_files:
     - petl/


### PR DESCRIPTION
## Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

## Changes

- Fixes conda-forge/petl-feedstock#35 (again)

